### PR TITLE
Decode the engine that ran a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,12 @@ execution, err := client.Execute(ctx, "bun-js", "", files)
 fmt.Println(execution.Runtime) // "bun"
 ```
 
-`Execution.Runtime` and `Event.Runtime` report which engine answered. Both are empty when
-the instance did not say — a language with one engine, or an instance older than the
-field, which includes the official API.
+`Runtime` on a listed runtime is reported by every instance, the official API included, so
+telling the engines apart and picking one works everywhere.
+
+Being told which engine *ran* a job is newer: `Execution.Runtime` and `Event.Runtime` are
+empty unless the instance says, which a language with one engine and an instance older
+than the field both do. Treat empty as "not stated", never as "unambiguous".
 
 Shorter, copy-paste snippets for each API also appear as [examples on pkg.go.dev](https://pkg.go.dev/github.com/milindmadhukar/go-piston/v2#pkg-examples).
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ dlrow olleh
 
 See the [examples directory](examples) for more, including timeouts, memory limits, multi-file execution, error handling, and configuring clients for self-hosted vs. the official API. Each is a runnable program; CI executes every one of them against a live instance on each push.
 
+### Choosing an engine
+
+One language can be served by several engines — `javascript` by node, deno and bun. They
+are separate entries in `GetRuntimes`, told apart by `Runtime`:
+
+```go
+for _, runtime := range runtimes {
+	fmt.Println(runtime.Language, runtime.Version, runtime.Runtime, runtime.Aliases)
+	// javascript 20.11.1 node [node-javascript node-js javascript js]
+	// javascript 1.3.14  bun  [bun-js]
+}
+```
+
+An instance resolves a request by taking the **highest version** that matches the name or
+one of its aliases, and versions are each engine's own — node 20 outranks bun 1.3 for no
+better reason than being a larger number. So a bare language name is not a way to ask for
+an engine. Pass an alias that belongs to one:
+
+```go
+execution, err := client.Execute(ctx, "bun-js", "", files)
+fmt.Println(execution.Runtime) // "bun"
+```
+
+`Execution.Runtime` and `Event.Runtime` report which engine answered. Both are empty when
+the instance did not say — a language with one engine, or an instance older than the
+field, which includes the official API.
+
 Shorter, copy-paste snippets for each API also appear as [examples on pkg.go.dev](https://pkg.go.dev/github.com/milindmadhukar/go-piston/v2#pkg-examples).
 
 ## Error handling

--- a/execute_unit_test.go
+++ b/execute_unit_test.go
@@ -1,0 +1,57 @@
+package gopiston
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeExecute stands up an instance whose /execute answers with the given body.
+func fakeExecute(t *testing.T, body string) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	return NewClient(server.URL, WithHTTPClient(server.Client()))
+}
+
+// A language served by several engines resolves by version number, so the
+// engine that ran the job is only knowable if the instance names it.
+func TestExecutionCarriesRuntime(t *testing.T) {
+	client := fakeExecute(t, `{
+		"language": "javascript",
+		"version": "1.3.14",
+		"runtime": "bun",
+		"run": {"stdout": "ok\n", "stderr": "", "output": "ok\n", "code": 0, "signal": null}
+	}`)
+
+	execution, err := client.Execute(context.Background(), "bun-js", "*", []File{{Content: "x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert(execution.Language, "javascript", t)
+	assert(execution.Runtime, "bun", t)
+}
+
+// Absence is the common case and the only thing an upstream instance can
+// report, so it must decode to empty rather than failing.
+func TestExecutionWithoutRuntime(t *testing.T) {
+	client := fakeExecute(t, `{
+		"language": "bash",
+		"version": "5.2.0",
+		"run": {"stdout": "ok\n", "stderr": "", "output": "ok\n", "code": 0, "signal": null}
+	}`)
+
+	execution, err := client.Execute(context.Background(), "bash", "*", []File{{Content: "x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert(execution.Runtime, "", t)
+}

--- a/interactive.go
+++ b/interactive.go
@@ -53,6 +53,7 @@ type wsMessage struct {
 	// Server to client only.
 	Language string `json:"language,omitempty"`
 	Version  string `json:"version,omitempty"`
+	Runtime  string `json:"runtime,omitempty"`
 	Stage    string `json:"stage,omitempty"`
 	Code     *int   `json:"code,omitempty"`
 	Message  string `json:"message,omitempty"`
@@ -145,6 +146,7 @@ func (session *Session) Next(ctx context.Context) (Event, error) {
 	event := Event{
 		Language: msg.Language,
 		Version:  msg.Version,
+		Runtime:  msg.Runtime,
 		Stage:    msg.Stage,
 		Data:     msg.Data,
 		Code:     msg.Code,

--- a/interactive_unit_test.go
+++ b/interactive_unit_test.go
@@ -156,6 +156,46 @@ func TestSessionEventSequence(t *testing.T) {
 	}
 }
 
+// The runtime frame is the only place an interactive session learns which
+// engine it got, and the field is absent whenever the instance has nothing to
+// disambiguate — or predates the field entirely.
+func TestSessionRuntimeEventCarriesEngine(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame map[string]any
+		want  string
+	}{
+		{
+			name:  "engine named",
+			frame: map[string]any{"type": "runtime", "language": "javascript", "version": "1.3.14", "runtime": "bun"},
+			want:  "bun",
+		},
+		{
+			name:  "engine omitted",
+			frame: map[string]any{"type": "runtime", "language": "bash", "version": "5.2.0"},
+			want:  "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakeInstance(t, func(ctx context.Context, conn *websocket.Conn) {
+				readMessage(ctx, conn)
+				writeEvent(ctx, conn, tc.frame)
+				conn.Close(CloseJobCompleted, "Job Completed")
+			})
+
+			session, err := client.Connect(context.Background(), "x", "", []File{{Content: "x"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer session.Close()
+
+			event := mustNext(t, session, context.Background())
+			assert(event.Type, EventRuntime, t)
+			assert(event.Runtime, tc.want, t)
+		})
+	}
+}
+
 // A stage ended by a signal reports a null code, which must stay
 // distinguishable from a genuine exit code of zero.
 func TestSessionExitBySignal(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -16,6 +16,12 @@ type Runtime struct {
 	// Runtime names the engine running the language, and is set only when the
 	// language has more than one possible engine (for example "node" or "deno"
 	// for JavaScript).
+	//
+	// Language and Version alone do not identify an engine: an instance picks
+	// the highest version satisfying the request, and versions are the engine's
+	// own, so node 20 outranks bun 1.3 for no better reason. To run on a
+	// particular engine, pass one of that entry's Aliases as the language —
+	// every engine sharing a language has at least one alias of its own.
 	Runtime string `json:"runtime,omitempty"`
 }
 
@@ -60,6 +66,14 @@ type Execution struct {
 
 	// Version is the version of the runtime that ran the job.
 	Version string `json:"version"`
+
+	// Runtime is the engine that ran the job — "node", "deno" or "bun" for
+	// JavaScript — and is set only for a language served by more than one.
+	//
+	// Empty means the instance did not say, which covers both a language with a
+	// single engine and any instance predating the field, including every
+	// upstream one. Absence is not a signal that the language is unambiguous.
+	Runtime string `json:"runtime,omitempty"`
 
 	// Run holds the results of the run stage.
 	Run Stage `json:"run"`
@@ -154,6 +168,11 @@ type Event struct {
 	// Version is the version of the runtime that ran the job. EventRuntime
 	// only.
 	Version string
+
+	// Runtime is the engine that ran the job, on the same terms as
+	// Execution.Runtime: set only for a language with more than one, empty
+	// whenever the instance did not say. EventRuntime only.
+	Runtime string
 
 	// Stage is "compile" or "run". EventStage and EventExit only.
 	Stage string

--- a/runtimes.go
+++ b/runtimes.go
@@ -51,6 +51,11 @@ func (client *Client) GetLanguages(ctx context.Context) ([]string, error) {
 //
 // Execute resolves an empty version server-side, so calling this first is only
 // necessary when the version itself is of interest.
+//
+// It compares across engines, exactly as the instance does. Asking for the
+// latest "javascript" on an instance running both node 20 and bun 1.3 answers
+// 20.11.1 — the version of whichever engine numbers highest, not a judgement
+// about which is newer. Pass an engine's own alias ("bun-js") to scope it.
 func (client *Client) GetLatestVersion(ctx context.Context, language string) (string, error) {
 	runtimes, err := client.GetRuntimes(ctx)
 	if err != nil {

--- a/runtimes_test.go
+++ b/runtimes_test.go
@@ -76,3 +76,77 @@ func TestGetLatestVersionInvalidLanguage(t *testing.T) {
 		t.Errorf("Expected ErrLanguageNotFound, got %v", err)
 	}
 }
+
+// An engine's own alias is the only stable way to ask for it: a bare language
+// name resolves by version number, and versions do not compare across engines.
+//
+// Skipped unless the instance actually installs two engines for one language,
+// which is the normal state of both the official API and a fresh instance.
+func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
+	requireExecuteAccess(t)
+
+	runtimes, err := client.GetRuntimes(testContext(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// language -> engine -> the aliases that engine claims for it.
+	shared := map[string]map[string][]string{}
+	for _, runtime := range runtimes {
+		if runtime.Runtime == "" {
+			continue
+		}
+		if shared[runtime.Language] == nil {
+			shared[runtime.Language] = map[string][]string{}
+		}
+		shared[runtime.Language][runtime.Runtime] = append(
+			shared[runtime.Language][runtime.Runtime], runtime.Aliases...)
+	}
+
+	tested := 0
+	for language, engines := range shared {
+		if len(engines) < 2 {
+			continue
+		}
+
+		for engine, aliases := range engines {
+			alias := exclusiveAlias(aliases, engine, engines)
+			if alias == "" {
+				t.Errorf("%s on %s has no alias of its own, so it cannot be asked for", language, engine)
+				continue
+			}
+
+			// An empty program: the assertion is about which engine answered,
+			// not about what it did, and every engine accepts an empty file.
+			execution, err := client.Execute(testContext(t), alias, "*", []File{{Content: ""}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert(execution.Language, language, t)
+			assert(execution.Runtime, engine, t)
+			tested++
+		}
+	}
+
+	if tested == 0 {
+		t.Skip("skipping: no language on this instance is served by more than one engine")
+	}
+}
+
+// exclusiveAlias returns an alias of engine that no other engine of the same
+// language also claims, or "" when there is none.
+func exclusiveAlias(aliases []string, engine string, engines map[string][]string) string {
+	for _, alias := range aliases {
+		taken := false
+		for other, theirs := range engines {
+			if other != engine && slices.Contains(theirs, alias) {
+				taken = true
+				break
+			}
+		}
+		if !taken {
+			return alias
+		}
+	}
+	return ""
+}

--- a/runtimes_test.go
+++ b/runtimes_test.go
@@ -80,8 +80,12 @@ func TestGetLatestVersionInvalidLanguage(t *testing.T) {
 // An engine's own alias is the only stable way to ask for it: a bare language
 // name resolves by version number, and versions do not compare across engines.
 //
-// Skipped unless the instance actually installs two engines for one language,
-// which is the normal state of both the official API and a fresh instance.
+// The check that works everywhere is the version that comes back — asking for
+// deno must answer with deno's version, not with node's higher one — because
+// naming the engine in an execute response is newer than the /runtimes field
+// that distinguishes them, so it is asserted only where it is reported.
+//
+// Skipped unless the instance really has two engines for one language.
 func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
 	requireExecuteAccess(t)
 
@@ -90,17 +94,17 @@ func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// language -> engine -> the aliases that engine claims for it.
-	shared := map[string]map[string][]string{}
+	// language -> engine -> that engine's runtimes for it.
+	shared := map[string]map[string][]Runtime{}
 	for _, runtime := range runtimes {
 		if runtime.Runtime == "" {
 			continue
 		}
 		if shared[runtime.Language] == nil {
-			shared[runtime.Language] = map[string][]string{}
+			shared[runtime.Language] = map[string][]Runtime{}
 		}
 		shared[runtime.Language][runtime.Runtime] = append(
-			shared[runtime.Language][runtime.Runtime], runtime.Aliases...)
+			shared[runtime.Language][runtime.Runtime], runtime)
 	}
 
 	tested := 0
@@ -109,8 +113,8 @@ func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
 			continue
 		}
 
-		for engine, aliases := range engines {
-			alias := exclusiveAlias(aliases, engine, engines)
+		for engine, installed := range engines {
+			alias, latest := exclusiveAlias(installed, engine, engines)
 			if alias == "" {
 				t.Errorf("%s on %s has no alias of its own, so it cannot be asked for", language, engine)
 				continue
@@ -123,7 +127,10 @@ func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
 				t.Fatal(err)
 			}
 			assert(execution.Language, language, t)
-			assert(execution.Runtime, engine, t)
+			assert(execution.Version, latest, t)
+			if execution.Runtime != "" {
+				assert(execution.Runtime, engine, t)
+			}
 			tested++
 		}
 	}
@@ -133,20 +140,36 @@ func TestExecuteSelectsAnEngineByAlias(t *testing.T) {
 	}
 }
 
-// exclusiveAlias returns an alias of engine that no other engine of the same
-// language also claims, or "" when there is none.
-func exclusiveAlias(aliases []string, engine string, engines map[string][]string) string {
-	for _, alias := range aliases {
-		taken := false
-		for other, theirs := range engines {
-			if other != engine && slices.Contains(theirs, alias) {
-				taken = true
-				break
+// exclusiveAlias returns an alias belonging to engine alone, along with the
+// highest version installed for it — what asking by that alias should resolve
+// to. The alias is empty when every name this engine answers to is also
+// claimed by another engine of the same language.
+func exclusiveAlias(installed []Runtime, engine string, engines map[string][]Runtime) (string, string) {
+	others := map[string]bool{}
+	for name, runtimes := range engines {
+		if name == engine {
+			continue
+		}
+		for _, runtime := range runtimes {
+			for _, alias := range runtime.Aliases {
+				others[alias] = true
 			}
 		}
-		if !taken {
-			return alias
+	}
+
+	latest := ""
+	for _, runtime := range installed {
+		if latest == "" || CompareVersions(runtime.Version, latest) > 0 {
+			latest = runtime.Version
 		}
 	}
-	return ""
+
+	for _, runtime := range installed {
+		for _, alias := range runtime.Aliases {
+			if !others[alias] {
+				return alias, latest
+			}
+		}
+	}
+	return "", latest
 }


### PR DESCRIPTION
An instance can serve one language from several engines — javascript from node, deno and bun — and resolves a request by taking the highest version matching the name or an alias. Versions are each engine's own, so a bare `javascript` answers with whichever engine numbers highest, and nothing in the reply said which one that was.

`Execution.Runtime` and `Event.Runtime` carry it now, where the instance reports it.

## Compatibility

Empty means the instance did not say: a single-engine language, or any instance older than the field, which includes the official API. The docs are explicit that absence is **not** a claim the language is unambiguous.

No probe and no capability gate — the empty string is the whole story. That is the reason this is a response field and not a request one: a `runtime` field on the request would be silently ignored by upstream and emkc, turning "run this on bun" into "ran on node" with no error. Asking for an engine stays a matter of passing an alias that belongs to it, which is data from `/runtimes` and therefore works against the fork, upstream and emkc alike.

## Tests

`TestExecuteSelectsAnEngineByAlias` is live and proves the selection end to end, but skips unless the instance really has two engines for one language — so it stays green on the upstream image in the CI matrix. Unit tests cover both decode paths with the field present and absent.

https://claude.ai/code/session_01HctWescqJSbxdH9nHPmtYs